### PR TITLE
README: add a link to the Docker Hub page of this container

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@ to this folder and run the `docker build` command ([docs][docker-build])
 
 	docker build --tag organization/grade-julia:tag .
 
-in the terminal emulator of your choice.
+in the terminal emulator of your choice. Also see the [Docker Hub page][Docker Hub] for this
+repository.
 
 [Julia]: https://julialang.org/
 [A+]: https://apluslms.github.io/
 [install Docker]: https://docs.docker.com/get-docker/
 [docker-build]: https://docs.docker.com/engine/reference/commandline/build/
+[Docker Hub]: https://hub.docker.com/repository/docker/sesodesa/grade-julia


### PR DESCRIPTION
Since the Docker Hub page links here, it does not hurt to also link the other way.